### PR TITLE
remove contents of doc files from log calls

### DIFF
--- a/app/coffee/Features/Project/ProjectEntityHandler.coffee
+++ b/app/coffee/Features/Project/ProjectEntityHandler.coffee
@@ -97,7 +97,7 @@ module.exports = ProjectEntityHandler =
 			confirmFolder project, folder_id, (folder_id)=>
 				doc = new Doc name: docName, lines: docLines
 				Project.putElement project._id, folder_id, doc, "doc", (err, result)=>
-					tpdsUpdateSender.addDoc {project_id:project._id, docLines:docLines, path:result.path.fileSystem, project_name:project.name, rev:doc.rev}, sl_req_id, ->
+					tpdsUpdateSender.addDoc {project_id:project._id, path:result.path.fileSystem, project_name:project.name, rev:doc.rev}, sl_req_id, ->
 						callback(err, doc, folder_id)
 
 	addFile: (project_or_id, folder_id, fileName, path, sl_req_id, callback = (error, fileRef, folder_id) ->)->
@@ -217,10 +217,10 @@ module.exports = ProjectEntityHandler =
 						logger.err "error putting doc #{doc_id} in project #{project_id} #{err}"
 						callback err
 					else if docComparitor.areSame docLines, doc.lines
-						logger.log sl_req_id: sl_req_id, docLines:docLines, project_id:project_id, doc_id:doc_id, rev:doc.rev, "old doc lines are same as the new doc lines, not updating them"
+						logger.log sl_req_id: sl_req_id, project_id:project_id, doc_id:doc_id, rev:doc.rev, "old doc lines are same as the new doc lines, not updating them"
 						callback()
 					else
-						logger.log sl_req_id: sl_req_id, project_id:project_id, doc_id:doc_id, docLines: docLines, oldDocLines: doc.lines, rev:doc.rev, "updating doc lines"
+						logger.log sl_req_id: sl_req_id, project_id:project_id, doc_id:doc_id, rev:doc.rev, "updating doc lines"
 						conditons = _id:project_id
 						update = {$set:{}, $inc:{}}
 						changeLines = {}
@@ -234,7 +234,7 @@ module.exports = ProjectEntityHandler =
 								logger.err(sl_req_id:sl_req_id, doc_id:doc_id, project_id:project_id, err:err, "error saving doc to mongo")
 								callback(err)
 							else
-								logger.log sl_req_id:sl_req_id, doc_id:doc_id, project_id:project_id, newDocLines:docLines, oldDocLines:doc.lines,	 "doc saved to mongo"
+								logger.log sl_req_id:sl_req_id, doc_id:doc_id, project_id:project_id, "doc saved to mongo"
 								rev = doc.rev+1
 								projectUpdateHandler.markAsUpdated project_id
 							tpdsUpdateSender.addDoc {project_id:project_id, path:path.fileSystem, docLines:docLines, project_name:project.name, rev:rev}, sl_req_id, callback

--- a/app/coffee/Features/ThirdPartyDataStore/TpdsUpdateSender.coffee
+++ b/app/coffee/Features/ThirdPartyDataStore/TpdsUpdateSender.coffee
@@ -40,7 +40,7 @@ module.exports =
 		{callback, sl_req_id} = slReqIdHelper.getCallbackAndReqId(callback, sl_req_id)
 		getProjectsUsersIds options.project_id, (err, user_id, allUserIds)->
 			return callback(err) if err?
-			logger.log project_id: options.project_id, user_id:user_id, path: options.path, rev:options.rev, uri:options.uri, project_name:options.project_name, docLines:options.docLines, sl_req_id:sl_req_id, "sending doc to third party data store"
+			logger.log project_id: options.project_id, user_id:user_id, path: options.path, rev:options.rev, uri:options.uri, project_name:options.project_name, sl_req_id:sl_req_id, "sending doc to third party data store"
 			postOptions =
 				method : "post"
 				headers: 

--- a/app/coffee/Features/ThirdPartyDataStore/UpdateMerger.coffee
+++ b/app/coffee/Features/ThirdPartyDataStore/UpdateMerger.coffee
@@ -52,7 +52,7 @@ module.exports =
 				if err?
 					logger.err project_id:project_id, doc_id:doc_id, fsPath:fsPath, "error reading file into text array for process doc update"
 					return callback(err)
-				logger.log docLines:docLines, doc_id:doc_id, project_id:project_id, sl_req_id:sl_req_id, "processing doc update from tpds"
+				logger.log doc_id:doc_id, project_id:project_id, sl_req_id:sl_req_id, "processing doc update from tpds"
 				if doc_id?
 					editorController.setDoc project_id, doc_id, docLines, sl_req_id, (err)->
 						callback()


### PR DESCRIPTION
A number of commands write the entire contents of a file to the output log, this stuffs the log quite rapidly and (since you have the doc id) to little benefit. I figured a pull would take about as much time as an issue to create, hence this.
