### PR TITLE
Bold and italic buttons

### DIFF
--- a/app/views/templates.jade
+++ b/app/views/templates.jade
@@ -152,6 +152,8 @@
 			#editorSplitter
 				#leftEditorPanel.ui-layout-center
 					#editorWrapper
+						#editorToolbar
+							| <strong><a href="#" class="js-bold">B</a> <i><a href="#" class="js-italic">I</a></i></strong>
 						#editor
 						#undoConflictWarning(style="display: none")
 							| <strong>Watch out!</strong> We had to undo some of your collaborators changes before we could undo yours.

--- a/public/coffee/editor/Editor.coffee
+++ b/public/coffee/editor/Editor.coffee
@@ -157,6 +157,30 @@ define [
 				position = @aceEditor.renderer.screenToTextCoordinates(e.clientX, e.clientY)
 				e.position = position
 				@trigger "mousemove", e
+				
+			boldBtn = $("#editorToolbar .js-bold")
+			boldBtn.off("click")
+			boldBtn.on "click", (e) ->
+					e.preventDefault()
+					if aceEditor.getSelection().isEmpty()
+						aceEditor.insert("\\textbf{}")
+						aceEditor.navigateLeft(1)
+					else
+						selection = aceEditor.getCopyText()
+						aceEditor.insert("\\textbf{" + selection + "}")
+					aceEditor.focus()
+			
+			italicBtn = $("#editorToolbar .js-italic")
+			italicBtn.off("click")
+			italicBtn.on "click", (e) ->
+					e.preventDefault()
+					if aceEditor.getSelection().isEmpty()
+						aceEditor.insert("\\textit{}")
+						aceEditor.navigateLeft(1)
+					else
+						selection = aceEditor.getCopyText()
+						aceEditor.insert("\\textit{" + selection + "}")	
+					aceEditor.focus()
 
 		setIdeToEditorPanel: (options = {}) ->
 			@aceEditor.focus()

--- a/public/stylesheets/less/editor.less
+++ b/public/stylesheets/less/editor.less
@@ -1081,3 +1081,20 @@ i[class*="sprite-"] {
 		margin-bottom: 6px;
 	}
 }
+
+#editorToolbar {
+	a {
+		font-size: 18px;
+		padding: 1px 5px;
+		background-color: rgb(220, 220, 220);
+		margin: 5px 0 5px 3px;
+		display: inline-block;
+		text-decoration: none;
+		width: 14px;
+		text-align: center;
+	}
+	a:hover {
+		background-color: rgb(180,180,180);
+		color: #FFF;
+	}
+}


### PR DESCRIPTION
I added shortcut buttons for the commonly used LaTeX commands `\textbf` and `\textit` in a toolbar on top of the editor. They enable you to apply those to either existing text (by selecting it) or use them as you type and start writing inside the curly braces.
The design of the buttons is probably not the best, but as I read in your blog post, that will anyway be changed soon.
Probably this technique could be used for other common commands, too (for example the math environments `$$` and `\[\]` and the `enumerate` and `itemize` environments).
