### PR TITLE
Add missing white space

### DIFF
--- a/app/views/project/list/project-list.jade
+++ b/app/views/project/list/project-list.jade
@@ -165,7 +165,7 @@
 							small #{translate("no_projects")}
 			div.welcome.text-centered(ng-if="projects.length == 0", ng-cloak)
 				h2 #{translate("welcome_to_sl")}
-				p #{translate("new_to_latex_look_at")}
+				p #{translate("new_to_latex_look_at")} 
 					a(href="/templates") #{translate("templates").toLowerCase()}
 					|   #{translate("or")}
 					a(href="/learn")  #{translate("latex_help_guide")}


### PR DESCRIPTION
On the welcome page a white space is missing between `our` and `templates`, as below:
![sharelatex-before](https://cloud.githubusercontent.com/assets/5656196/4111847/a1f42c02-3214-11e4-98fb-282f59db7307.png)

after fix:
![sharelatex-after](https://cloud.githubusercontent.com/assets/5656196/4111846/a1f016bc-3214-11e4-9f58-ed3f34ec4e8d.png)
