### PR TITLE
Add logic to bind the web app to a specific host

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -35,8 +35,8 @@ if Settings.catchErrors
 BackgroundTasks.run()
 
 port = Settings.port or Settings.internal?.web?.port or 3000
-localInterface = Settings.interface or "0.0.0.0"
-Server.server.listen port, localInterface, ->
+host = Settings.internal.web.host or "localhost"
+Server.server.listen port, host, ->
 	logger.info("web-sharelatex listening on port #{port}")
 	logger.info("#{require('http').globalAgent.maxSockets} sockets enabled")
 	if argv.user


### PR DESCRIPTION
Adds the logic to allow nodejs to bind to a specific host. This host can be set in `settings.coffee` as in https://github.com/sharelatex/sharelatex/pull/174. The default host is not changed; nodejs will listen to all hosts/interfaces.
