### PR TITLE
[docker] drop a useless chmod and chown in the build stage

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -12,9 +12,6 @@ wait $FORMAT && echo "Format complete" || exit 1
 wait $TRANSLATIONS && echo "Translations install complete" || exit 1
 wait $MINIFY && echo "Minifiy complete" || exit 1
 
-chmod -R 0755 /app/public
-chown -R node:node /app/public
-
 set -B
 
 rm -rf /app/data


### PR DESCRIPTION
In dropping the chmod/chown instruction we can lower the image size by about 73MB.

File content and file attributes are coupled together in docker. Changing any attribute of a file - e.g. the owner or permissions - results in a new entry for the file in another layer of image.

The CI passed here, so I assume it was not needed anyways. Otherwise we should refactor the install script into two parts. One for the build layer with the given chmod plus co and one for the final layer that creates the user data directories.