### PR TITLE
[make] simplify the acceptance tests run for modules

### DIFF
--- a/Makefile.module
+++ b/Makefile.module
@@ -21,6 +21,7 @@ MAIN_OUTPUT_FILES := $(subst public/src/main,../../public/js/main/$(MODULE_NAME)
 DOCKER_COMPOSE_FLAGS ?= -f docker-compose.yml
 DOCKER_COMPOSE_MODULE_FLAGS := ${DOCKER_COMPOSE_FLAGS} -f $(MODULE_DIR)/docker-compose.yml
 DOCKER_COMPOSE := cd ../../ && \
+	COMPOSE_PROJECT_NAME=acceptance_test_$(BUILD_DIR_NAME)_$(MODULE_NAME) \
 	MODULE_DIR=$(MODULE_DIR) \
 	BUILD_NUMBER=$(BUILD_NUMBER) \
 	BRANCH_NAME=$(BRANCH_NAME) \
@@ -67,5 +68,15 @@ compile_full:
 	if [ -e test/unit_frontend/src/ide ]; then $(BABEL) test/unit_frontend/src/ide --out-dir ../../test/unit_frontend/js/ide/$(MODULE_NAME); fi
 	@$(MAKE) compile
 
+ifeq (,$(wildcard test/acceptance))
+test_acceptance:
+clean_test_acceptance:
+
+else
 test_acceptance:
 	${DOCKER_COMPOSE} run --rm test_acceptance npm -q run test:acceptance:run_dir -- ${MOCHA_ARGS} $(MODULE_DIR)/test/acceptance/js
+
+clean_test_acceptance:
+	${DOCKER_COMPOSE} down -v -t 0
+
+endif


### PR DESCRIPTION
This is a followup for #666. The actual diff is https://github.com/sharelatex/web-sharelatex/compare/be0ad70cdc11fa3e505d5cf6e3de3358a935128d...a6261e6aeea2aeb6850c58b3f0841ee9a24086a7.

This PRs adds a `clean_test_acceptance` target into the module Makefile.

Additionally it uses the new fan out method of #666 for the test invocation and cleanup.

Modules without acceptance tests get empty build targets for the test run and cleanup.