### PR TITLE
[docker] change cleanup scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ clean_modules:
 clean_css:
 	rm -f public/stylesheets/*.css*
 
+clean_ci: clean_build
 clean_ci: clean_test_frontend
 	$(DOCKER_COMPOSE) down -v -t 0
 
@@ -273,6 +274,11 @@ build:
 	docker build --pull --tag ci/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \
 		--tag gcr.io/overleaf-ops/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \
 		.
+
+clean_build:
+	docker rmi -f \
+		ci/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \
+		gcr.io/overleaf-ops/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER) \
 
 build_test_frontend:
 	COMPOSE_PROJECT_NAME=frontend_$(BUILD_DIR_NAME) $(DOCKER_COMPOSE) build test_frontend

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,6 @@ clean_css:
 
 clean_ci: clean_build
 clean_ci: clean_test_frontend
-	$(DOCKER_COMPOSE) down -v -t 0
 
 test: test_unit test_frontend test_acceptance
 

--- a/Makefile
+++ b/Makefile
@@ -209,9 +209,6 @@ clean_css:
 
 clean_ci:
 	$(DOCKER_COMPOSE) down -v -t 0
-	docker container list | grep 'days ago' | cut -d ' ' -f 1 - | xargs -r docker container stop
-	docker image prune -af --filter "until=48h"
-	docker network prune -f
 
 test: test_unit test_frontend test_acceptance
 

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ clean_modules:
 clean_css:
 	rm -f public/stylesheets/*.css*
 
-clean_ci:
+clean_ci: clean_test_frontend
 	$(DOCKER_COMPOSE) down -v -t 0
 
 test: test_unit test_frontend test_acceptance
@@ -276,6 +276,10 @@ build:
 
 build_test_frontend:
 	COMPOSE_PROJECT_NAME=frontend_$(BUILD_DIR_NAME) $(DOCKER_COMPOSE) build test_frontend
+
+clean_test_frontend:
+	COMPOSE_PROJECT_NAME=frontend_$(BUILD_DIR_NAME) $(DOCKER_COMPOSE) down -v -t 0
+	docker rmi -f frontend_$(BUILD_DIR_NAME)_test_frontend
 
 publish:
 	docker push $(DOCKER_REPO)/$(PROJECT_NAME):$(BRANCH_NAME)-$(BUILD_NUMBER)


### PR DESCRIPTION
The CI pipeline should not remove resources that are not related to sharelatex.

While we are changing the cleanup behavior I added the cleanup of the build stage and the frontend image.

There is an option for docker-compose that can remove the images that were build by docker-compose: `--rmi local`. But it would error out in case the image is not present yet, so I used an explicit removal of the image name instead.