### PR TITLE
[logging] do not overwrite the logger name

### DIFF
--- a/app/coffee/Features/Downloads/ProjectZipStreamManager.coffee
+++ b/app/coffee/Features/Downloads/ProjectZipStreamManager.coffee
@@ -22,12 +22,12 @@ module.exports = ProjectZipStreamManager =
 				jobs.push (callback) ->
 					ProjectGetter.getProject project_id, name: true, (error, project) ->
 						return callback(error) if error?
-						logger.log project_id: project_id, name: project.name, "appending project to zip stream"
+						logger.log project_id: project_id, projectName: project.name, "appending project to zip stream"
 						ProjectZipStreamManager.createZipStreamForProject project_id, (error, stream) ->
 							return callback(error) if error?
 							archive.append stream, name: "#{project.name}.zip"
 							stream.on "end", () ->
-								logger.log project_id: project_id, name: project.name, "zip stream ended"
+								logger.log project_id: project_id, projectName: project.name, "zip stream ended"
 								callback()
 
 		async.series jobs, () ->

--- a/app/coffee/Features/Editor/EditorHttpController.coffee
+++ b/app/coffee/Features/Editor/EditorHttpController.coffee
@@ -63,7 +63,7 @@ module.exports = EditorHttpController =
 		name = req.body.name
 		parent_folder_id = req.body.parent_folder_id
 		user_id = AuthenticationController.getLoggedInUserId(req)
-		logger.log project_id:project_id, name:name, parent_folder_id:parent_folder_id, "getting request to add doc to project"
+		logger.log project_id:project_id, docName:name, parent_folder_id:parent_folder_id, "getting request to add doc to project"
 		if !EditorHttpController._nameIsAcceptableLength(name)
 			return res.sendStatus 400
 		EditorController.addDoc project_id, parent_folder_id, name, [], "editor", user_id, (error, doc) ->

--- a/app/coffee/Features/Project/ProjectController.coffee
+++ b/app/coffee/Features/Project/ProjectController.coffee
@@ -131,7 +131,7 @@ module.exports = ProjectController =
 		user_id = AuthenticationController.getLoggedInUserId(req)
 		projectName = req.body.projectName?.trim()
 		template = req.body.template
-		logger.log user: user_id, projectType: template, name: projectName, "creating project"
+		logger.log user: user_id, projectType: template, projectName: projectName, "creating project"
 		async.waterfall [
 			(cb)->
 				if template == 'example'
@@ -140,7 +140,7 @@ module.exports = ProjectController =
 					projectCreationHandler.createBasicProject user_id, projectName, cb
 		], (err, project)->
 			return next(err) if err?
-			logger.log project: project, user: user_id, name: projectName, templateType: template, "created project"
+			logger.log project: project, user: user_id, projectName: projectName, templateType: template, "created project"
 			res.send {project_id:project._id}
 
 

--- a/app/coffee/Features/Uploads/FileSystemImportManager.coffee
+++ b/app/coffee/Features/Uploads/FileSystemImportManager.coffee
@@ -9,7 +9,7 @@ module.exports = FileSystemImportManager =
 	addDoc: (user_id, project_id, folder_id, name, path, charset, replace, callback = (error, doc)-> )->
 		FileSystemImportManager._isSafeOnFileSystem path, (err, isSafe)->
 			if !isSafe
-				logger.log user_id:user_id, project_id:project_id, folder_id:folder_id, name:name, path:path, "add doc is from symlink, stopping process"
+				logger.log user_id:user_id, project_id:project_id, folder_id:folder_id, docName:name, path:path, "add doc is from symlink, stopping process"
 				return callback("path is symlink")
 			fs.readFile path, charset, (error, content) ->
 				return callback(error) if error?
@@ -23,7 +23,7 @@ module.exports = FileSystemImportManager =
 	addFile: (user_id, project_id, folder_id, name, path, replace, callback = (error, file)-> )->
 		FileSystemImportManager._isSafeOnFileSystem path, (err, isSafe)->
 			if !isSafe
-				logger.log user_id:user_id, project_id:project_id, folder_id:folder_id, name:name, path:path, "add file is from symlink, stopping insert"
+				logger.log user_id:user_id, project_id:project_id, folder_id:folder_id, fileName:name, path:path, "add file is from symlink, stopping insert"
 				return callback("path is symlink")
 
 			if replace

--- a/app/coffee/Features/Uploads/ProjectUploadController.coffee
+++ b/app/coffee/Features/Uploads/ProjectUploadController.coffee
@@ -52,7 +52,7 @@ module.exports = ProjectUploadController =
 		project_id   = req.params.Project_id
 		folder_id    = req.query.folder_id
 		if !name? or name.length == 0 or name.length > 150
-			logger.err project_id:project_id, name:name, "bad name when trying to upload file"
+			logger.err project_id:project_id, originalName:name, "bad name when trying to upload file"
 			return res.send success: false
 		logger.log folder_id:folder_id, project_id:project_id, "getting upload file request"
 		user_id = AuthenticationController.getLoggedInUserId(req)


### PR DESCRIPTION
Similar to https://github.com/sharelatex/filestore-sharelatex/pull/50.

The user provided document or filename overwrites the logger name in some cases.

This PR moves the names into dedicated fields.
