### PR TITLE
[misc] readme: fix a typo in the name of the parent repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a lot of logic around creating and editing projects, and account management.
 
 
 The rest of the Overleaf stack, along with information about contributing can be found in the
-[overleaf/ovelreaf](https://github.com/overleaf/overleaf) repository.
+[overleaf/overleaf](https://github.com/overleaf/overleaf) repository.
 
 Build process
 ----------------


### PR DESCRIPTION
As per the title.