### PR TITLE
Update UserGetter.js, fix getUserFullEmails

### DIFF
--- a/app/src/Features/User/UserGetter.js
+++ b/app/src/Features/User/UserGetter.js
@@ -68,7 +68,7 @@ const UserGetter = {
       }
 
       if (!Features.hasFeature('affiliations')) {
-        return callback(null, decorateFullEmails(user.email, user.emails, []))
+        return callback(null, decorateFullEmails(user.email, user.emails || [], []))
       }
 
       return getUserAffiliations(userId, function(error, affiliationsData) {


### PR DESCRIPTION
### Description

undefined user.emails cause crash.

#### Screenshots

When GET /user/emails , the mass happens.

The test user is created in V1 (using the script in https://github.com/overleaf/overleaf/wiki/Creating-and-managing-users#creating-the-first-admin-user ) and then migrated to V2.

```
/var/www/sharelatex/web/node_modules/mongodb/lib/utils.js:123
    process.nextTick(function() { throw err; });
                                  ^

TypeError: Cannot read property 'map' of undefined
    at decorateFullEmails (/var/www/sharelatex/web/app/src/Features/User/UserGetter.js:225:14)
    at /var/www/sharelatex/web/app/src/Features/User/UserGetter.js:71:31
    at /var/www/sharelatex/web/node_modules/metrics-sharelatex/statsd/timeAsyncMethod.coffee:49:25
    at /var/www/sharelatex/web/node_modules/mongojs/lib/collection.js:50:5
    at handleCallback (/var/www/sharelatex/web/node_modules/mongodb/lib/utils.js:120:56)
    at /var/www/sharelatex/web/node_modules/mongodb/lib/cursor.js:683:5
    at handleCallback (/var/www/sharelatex/web/node_modules/mongodb-core/lib/cursor.js:171:5)
    at nextFunction (/var/www/sharelatex/web/node_modules/mongodb-core/lib/cursor.js:691:5)
    at /var/www/sharelatex/web/node_modules/mongodb-core/lib/cursor.js:602:7
    at queryCallback (/var/www/sharelatex/web/node_modules/mongodb-core/lib/cursor.js:232:18)
    at /var/www/sharelatex/web/node_modules/mongodb-core/lib/connection/pool.js:469:18
    at process._tickCallback (internal/process/next_tick.js:61:11)
```

#### Related Issues / PRs

None
