### PR TITLE
fix Csrf.js, do not check csrf token for real-time

### DIFF
--- a/app/src/infrastructure/Csrf.js
+++ b/app/src/infrastructure/Csrf.js
@@ -47,6 +47,10 @@ module.exports = Csrf = class Csrf {
     // the request, to get a new csrf token for any rendered forms. For excluded routes we'll then ignore a 'bad csrf
     // token' error from csurf and continue on...
 
+    // do not check csrf token for real-time
+    if (req.path.startsWith('/socket.io/'))
+      return csrf(req, res, err => { next() });
+
     // check whether the request method is excluded for the specified route
     if (
       (this.excluded_routes[req.path] != null


### PR DESCRIPTION
### Description

If websocket is unreachable, the real-time module will fallback to `xhr-polling`, sending a POST to a URL like */socket.io/1/xhr-polling/ag51Cl7uqDzUxxxxxxxx?t=1569835600000* .

Real-time module auto select transport methods: https://github.com/overleaf/real-time/blob/2060a2fdc5c6badfa92a717a6ff35dfe91ad9f20/app.coffee#L54-L55

`xhr-polling` doesn't take a csrf token, causing the xhr request is rejected by the web frontend and is not proxied to the real-time module.

Since the request is initialized by real-time module, the csrf token should not be checked by the web frontend.

#### Screenshots

> POST http://localhost/socket.io/1/xhr-polling/ag51Cl7uqDzUxxxxxxxx?t=1569835600000 403 (Forbidden) @ socket.io.js:2