### PR TITLE
[model] User: add missing unique constraint on the email field

### DIFF
--- a/app/src/models/User.js
+++ b/app/src/models/User.js
@@ -16,7 +16,12 @@ const { ObjectId } = Schema
 const MAX_EMAIL_LENGTH = 254
 
 const UserSchema = new Schema({
-  email: { type: String, default: '', maxlength: MAX_EMAIL_LENGTH },
+  email: {
+    type: String,
+    default: '',
+    maxlength: MAX_EMAIL_LENGTH,
+    unique: true
+  },
   emails: [
     {
       email: { type: String, default: '', maxlength: MAX_EMAIL_LENGTH },


### PR DESCRIPTION
One of the Model acceptance tests [1] hints on a unique constraint for the email field of the User model, but it is missing in the model spec. This PR adds said constraint.

The mongodb connection for the user model has the `autoIndex` flag disabled [2], so this should not have an impact on the regular usage of this model.

---
[1] https://github.com/overleaf/web/blob/c6bf5eb8e161d2a1017c06c38ac5837974872d70/test/acceptance/src/ModelTests.js#L18-L22

[2] https://github.com/overleaf/web/blob/c6bf5eb8e161d2a1017c06c38ac5837974872d70/app/src/models/User.js#L132 