### PR TITLE
[model] Subscription: add missing constrains for the manager_ids

### DIFF
--- a/app/src/models/Subscription.js
+++ b/app/src/models/Subscription.js
@@ -23,7 +23,16 @@ const SubscriptionSchema = new Schema({
     ref: 'User',
     index: { unique: true, dropDups: true }
   },
-  manager_ids: { type: [ObjectId], ref: 'User', required: true },
+  manager_ids: {
+    type: [ObjectId],
+    ref: 'User',
+    required: true,
+    unique: true,
+    validate: function(managers) {
+      // require at least one manager
+      return !!managers.length
+    }
+  },
   member_ids: [{ type: ObjectId, ref: 'User' }],
   invited_emails: [String],
   teamInvites: [TeamInviteSchema],


### PR DESCRIPTION
One of the Model acceptance tests [1] verifies that at least one manager must be present for an arbitrary Subscription, but there is no such guard in the OSS version. This PR adds a validate function to check the number of managers.

Another test [2] validates that an arbitrary manager can manage at most one Subscription. This PR adds a unique constraint on the manager list of the Subscription model.

The mongodb connection for the Subscription model has the `autoIndex` flag disabled [3], so this should not have an impact on the regular usage of this model.

---
[1] https://github.com/overleaf/web/blob/c6bf5eb8e161d2a1017c06c38ac5837974872d70/test/acceptance/src/ModelTests.js#L41-L43

[2] https://github.com/overleaf/web/blob/c6bf5eb8e161d2a1017c06c38ac5837974872d70/test/acceptance/src/ModelTests.js#L45-L61

[3] https://github.com/overleaf/web/blob/c6bf5eb8e161d2a1017c06c38ac5837974872d70/app/src/models/Subscription.js#L63