### PR TITLE
[misc] do not force a scrollbar on the project list view

### DIFF
--- a/public/stylesheets/app/project-list.less
+++ b/public/stylesheets/app/project-list.less
@@ -90,7 +90,7 @@
   padding-bottom: @content-margin-vertical;
   height: 100%;
   margin-left: -(@grid-gutter-width / 2);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .project-header {


### PR DESCRIPTION
The actual project list (wrapper) does not overflow.

Git blame on the line suggests that optional SSO notifications may
 cause an overflow.

Let's hide the scrollbar by default and only show it when necessary.

REF: ebb6cc5adeab5135fb65a5401535e1c5fe320c1e
cc @lawshe 