### PR TITLE
[misc] test/unit: EmailSenderTests: fix a bad promises reference

### DIFF
--- a/test/unit/src/Email/EmailSenderTests.js
+++ b/test/unit/src/Email/EmailSenderTests.js
@@ -117,7 +117,7 @@ describe('EmailSender', function() {
     it('should not check the rate limiter when there is no sendingUser_id', async function() {
       this.EmailSender.sendEmail(this.opts, () => {
         expect(this.sesClient.sendMail).to.have.been.called
-        expect(this.RateLimiter.addCount).not.to.have.been.called
+        expect(this.RateLimiter.promises.addCount).not.to.have.been.called
       })
     })
 


### PR DESCRIPTION
### Description
The transition to promises for the email sending left one reference on the base object.

The current `chai` version did not bother with `expect(undefined).not.to.have.been.called`, but future versions do.

REF: 6d42e13dda70fb0ac196880cc24c5524f79f87b2
REF: 3d33147c18e2d652976b3dac7453c0407c81314e


#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
