### PR TITLE
[SystemMessageManager] getMessages: caching: queue concurrent requests

### DIFF
--- a/app/src/Features/SystemMessages/SystemMessageManager.js
+++ b/app/src/Features/SystemMessages/SystemMessageManager.js
@@ -13,21 +13,26 @@ let SystemMessageManager
 const { SystemMessage } = require('../../models/SystemMessage')
 
 module.exports = SystemMessageManager = {
+  pending: [],
+
   getMessages(callback) {
     if (callback == null) {
       callback = function(error, messages) {}
     }
     if (this._cachedMessages != null) {
       return callback(null, this._cachedMessages)
-    } else {
-      return this.getMessagesFromDB((error, messages) => {
-        if (error != null) {
-          return callback(error)
-        }
-        this._cachedMessages = messages
-        return callback(null, messages)
-      })
     }
+    if (this.pending.push(callback) !== 1) {
+      return
+    }
+    this.getMessagesFromDB((error, messages) => {
+      if (error == null) {
+        this._cachedMessages = messages
+      }
+      const pending = this.pending
+      this.pending = []
+      pending.forEach(cb => process.nextTick(cb, error, messages))
+    })
   },
 
   getMessagesFromDB(callback) {

--- a/test/unit/src/SystemMessages/SystemMessageManagerTests.js
+++ b/test/unit/src/SystemMessages/SystemMessageManagerTests.js
@@ -75,6 +75,19 @@ describe('SystemMessageManager', function() {
         return this.callback.calledWith(null, this.messages).should.equal(true)
       })
     })
+
+    describe('with many requests inflight', function() {
+      beforeEach(function() {
+        this.SystemMessage.find = sinon.stub()
+        for (let i of Array.from({ length: 100 })) {
+          this.SystemMessageManager.getMessages()
+        }
+      })
+
+      it('should send only one database request', function() {
+        this.SystemMessage.find.callCount.should.equal(1)
+      })
+    })
   })
 
   describe('clearMessages', function() {


### PR DESCRIPTION
### Description
The `SystemMessageManager` is queried for every single inflight http
 request [0].
There is a basic cache for system messages [1], which is empty on startup
 and purged every 20 seconds [2]. 
An inflight request will trigger a db request to fill this cache. But
 there is no locking or syncing with concurrent requests, so they all
 trigger an individual db request. Once any of the db requests
 completed, following requests can use the last db response.

There should be only one request to the db for concurrent inflight
 http requests.


_Actually the system messages are not needed for every request, just those that render the default layout [3]. API request - such as a project compile request - do not need the messages at all. But to fix this logic flaw, there is much more work to do._
_Edit: PR for that is https://github.com/overleaf/web/pull/700_

#### Screenshots

Here is my test setup:
- a bash script which fires 5 concurrent requests with detached curl requests

  <pre>$ for i in `seq 5`; do curl -I .../system/messages/404 & done</pre>
- a web service connected to a mongo db via a link that has some latency - e.g. in a different geographic location. For this test there is a latency of about 10 ms, this not a dedicated link, so there is some jitter.

With some basic delay logging in place [4] we can see the 

<details>
<summary>before</summary>

```
{"name":"web","hostname":"94c8d7bdf53c","pid":1,"level":40,"delay":14.497115,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:51:14.840Z","v":0}
{"name":"web","hostname":"94c8d7bdf53c","pid":1,"level":40,"delay":19.981856,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:51:14.850Z","v":0}
{"name":"web","hostname":"94c8d7bdf53c","pid":1,"level":40,"delay":0.00671,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:51:14.860Z","v":0}
{"name":"web","hostname":"94c8d7bdf53c","pid":1,"level":40,"delay":0.007958,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:51:14.867Z","v":0}
{"name":"web","hostname":"94c8d7bdf53c","pid":1,"level":40,"delay":42.270616,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:51:14.873Z","v":0}
```

notice the last line!

---
</details>

<details>
<summary>after</summary>

```
{"name":"web","hostname":"b11285b83675","pid":1,"level":40,"delay":8.354598,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:46:15.102Z","v":0}
{"name":"web","hostname":"b11285b83675","pid":1,"level":40,"delay":9.835488,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:46:15.107Z","v":0}
{"name":"web","hostname":"b11285b83675","pid":1,"level":40,"delay":16.689174,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:46:15.118Z","v":0}
{"name":"web","hostname":"b11285b83675","pid":1,"level":40,"delay":0.006051,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:46:15.123Z","v":0}
{"name":"web","hostname":"b11285b83675","pid":1,"level":40,"delay":0.003367,"path":"/system/messages/404","msg":"SystemMessageManager.getMessages","time":"2019-11-14T10:46:15.127Z","v":0}
```
</details>

#### Related Issues / PRs



### Review



#### Potential Impact
High! every request runs through this middle ware.


#### Manual Testing Performed

- see above
- project list/editor work

#### Accessibility



### Deployment



#### Deployment Checklist

#### Metrics and Monitoring



#### Who Needs to Know?


---
[0] https://github.com/overleaf/web/blob/0b0fd21a9f4b04501c939d346db3679a5695c56f/app/src/infrastructure/ExpressLocals.js#L336-L337
[1] https://github.com/overleaf/web/blob/0b0fd21a9f4b04501c939d346db3679a5695c56f/app/src/Features/SystemMessages/SystemMessageManager.js#L20-L27
[2] https://github.com/overleaf/web/blob/0b0fd21a9f4b04501c939d346db3679a5695c56f/app/src/Features/SystemMessages/SystemMessageManager.js#L60-L61
[3] https://github.com/overleaf/web/blob/0b0fd21a9f4b04501c939d346db3679a5695c56f/app/views/layout.pug#L65
[4] <details>
<summary> delay logging </summary>

```diff
diff --git a/app/src/infrastructure/ExpressLocals.js b/app/src/infrastructure/ExpressLocals.js
index 2d26ac2b2..45b7fa3f2 100644
--- a/app/src/infrastructure/ExpressLocals.js
+++ b/app/src/infrastructure/ExpressLocals.js
@@ -333,7 +333,8 @@ module.exports = function(webRouter, privateApiRouter, publicApiRouter) {
     next()
   })
 
-  webRouter.use((req, res, next) =>
+  webRouter.use((req, res, next) => {
+    const one = process.hrtime()
     SystemMessageManager.getMessages(function(error, messages) {
       if (error) {
         return next(error)
@@ -342,9 +343,17 @@ module.exports = function(webRouter, privateApiRouter, publicApiRouter) {
         messages = []
       }
       res.locals.systemMessages = messages
+      const diff = process.hrtime(one)
+      logger.warn(
+        {
+          delay: diff[0] * 1000 + diff[1] / 1000000,
+          path: req.originalUrl
+        },
+        'SystemMessageManager.getMessages'
+      )
       next()
     })
-  )
+  })
 
   webRouter.use(function(req, res, next) {
     if (Settings.reloadModuleViewsOnEachRequest) {
```
</details>