### PR TITLE
Added 'csv' to list of editable text file extensions

### DIFF
--- a/app/src/Features/Uploads/FileTypeManager.js
+++ b/app/src/Features/Uploads/FileTypeManager.js
@@ -33,7 +33,8 @@ module.exports = FileTypeManager = {
     'lbx',
     'bbx',
     'cbx',
-    'm'
+    'm',
+    'csv'
   ],
 
   IGNORE_EXTENSIONS: [


### PR DESCRIPTION
This allows files with extension '.cvs' to be editable in the overleaf editor 