### PR TITLE
[test/unit] models/Project: add missing stubs for model dependencies

### DIFF
--- a/test/unit/src/helpers/models/Doc.js
+++ b/test/unit/src/helpers/models/Doc.js
@@ -1,0 +1,3 @@
+const mockModel = require('../MockModel')
+
+module.exports = mockModel('Doc')

--- a/test/unit/src/helpers/models/File.js
+++ b/test/unit/src/helpers/models/File.js
@@ -1,0 +1,3 @@
+const mockModel = require('../MockModel')
+
+module.exports = mockModel('File')

--- a/test/unit/src/helpers/models/Folder.js
+++ b/test/unit/src/helpers/models/Folder.js
@@ -1,0 +1,6 @@
+const mockModel = require('../MockModel')
+
+module.exports = mockModel('Folder', {
+  './File': require('./File'),
+  './Doc': require('./Doc')
+})

--- a/test/unit/src/helpers/models/Project.js
+++ b/test/unit/src/helpers/models/Project.js
@@ -1,3 +1,3 @@
 const mockModel = require('../MockModel')
 
-module.exports = mockModel('Project')
+module.exports = mockModel('Project', { './Folder': require('./Folder') })


### PR DESCRIPTION
### Description

The models share a single connection pool now, which is connected on
 import/require.
Stub all model dependencies of the Project model to cancel the
 dependency on a running mongodb instance for the unit tests.

REF: 47a21177f38f359a165f4d5b2c5556d95dab55f7
REF: d227b7eb36f130085c9eb1480dc07bd50ba57768


#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
