### PR TITLE
[RateLimiterMiddlewareTests] add a missing stub for LoginRateLimiter

### DIFF
--- a/test/unit/src/Security/RateLimiterMiddlewareTests.js
+++ b/test/unit/src/Security/RateLimiterMiddlewareTests.js
@@ -39,6 +39,7 @@ describe('RateLimiterMiddleware', function() {
       requires: {
         'settings-sharelatex': (this.settings = {}),
         '../../infrastructure/RateLimiter': (this.RateLimiter = {}),
+        './LoginRateLimiter': {},
         'logger-sharelatex': (this.logger = { warn: sinon.stub() }),
         '../Authentication/AuthenticationController': this
           .AuthenticationController


### PR DESCRIPTION
### Description

Without this stub, the LoginRateLimiter spams the unit test logs for
 a missing redis connection.

<details>
<summary> some 2300 lines like this </summary>

<pre>
using noop

[ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379

  at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1128:14)



[ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379

  at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1128:14)



[ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379

  at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1128:14)
</pre>
</details>

REF: 9e07a7d040d6cf61ef92015665f7d65b45241188
REF: a0da310e5537b420e46c9ed48f8b97051e7e933a

#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
