### PR TITLE
[ErrorController] handleError: access session gracefully

### DIFF
--- a/app/src/Features/Errors/ErrorController.js
+++ b/app/src/Features/Errors/ErrorController.js
@@ -23,7 +23,7 @@ module.exports = ErrorController = {
   handleError(error, req, res, next) {
     const user = AuthenticationController.getSessionUser(req)
     // log errors related to SAML flow
-    if (req.session.saml) {
+    if (req.session && req.session.saml) {
       SamlLogHandler.log(req.session.saml.universityId, req.sessionID, {
         error: {
           message: error && error.message,


### PR DESCRIPTION
### Description
Session errors may get catched by this error handler, hence we can not
 access any session data without checking for an existing session first.

Unfortunately I do not have the full traceback anymore.

REF: aed1d434b91c9f4233811eaa00f8418a8b781235
REF: bc5e5cafbd4c5da7ba33891fa738efa9a95c5332


#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
