### PR TITLE
[HealthCheckController] fix a race in the loading of the SmokeTests

### DIFF
--- a/app/src/Features/HealthCheck/HealthCheckController.js
+++ b/app/src/Features/HealthCheck/HealthCheckController.js
@@ -96,7 +96,9 @@ var Reporter = res =>
     const tests = []
     const passes = []
     const failures = []
+    let runnerProcessedAnyTestSuite = false
 
+    runner.on('suite', () => (runnerProcessedAnyTestSuite = true))
     runner.on('test end', test => tests.push(test))
     runner.on('pass', test => passes.push(test))
     runner.on('fail', test => failures.push(test))
@@ -119,6 +121,10 @@ var Reporter = res =>
       if (failures.length > 0) {
         logger.err({ failures }, 'health check failed')
         return res.status(500).send(JSON.stringify(results, null, 2))
+      } else if (!runnerProcessedAnyTestSuite) {
+        const err = 'no test suites were processed'
+        logger.err({ err }, 'health check failed soft')
+        return res.status(500).send({ err })
       } else {
         return res.status(200).send(JSON.stringify(results, null, 2))
       }


### PR DESCRIPTION
### Description

There is a race between loading, executing and unloading of the test
 module: the module registers its suites only once during its lifecycle.

Running health checks in parallel could result in the loading of a
 cached copy of the module and mocha would see 0 (new) test suites.
See below how easy it is to trigger the race.

In case of a failing service, only one of the many requests would see
 the actual failure on the `/health_check` route, others see a
 success response. In the next check cycle a different agent would
 read the failure status.

I could not replicate the race condition with 5/10/20/50/75/100
 concurrent requests after applying the patches.
Just in case we hit it again, there is a guard that tracks any run suite
 and bails out with a 500 and a response payload of
 `{"err":"no test suites were processed"}` in case none was
 processed.

#### Screenshots
<details>
<summary> before (with empty test suite) </summary>

```
$ curl 127.0.0.1:3000/health_check & curl 127.0.0.1:3000/health_check
{
  "stats": {
    "suites": 0,
    "tests": 0,
    "passes": 0,
    "pending": 0,
    "failures": 0,
    "start": "2019-11-23T21:50:10.681Z",
    "end": "2019-11-23T21:50:10.681Z",
    "duration": 0
  },
  "failures": [],
  "passes": []
}{
  "stats": {
    "suites": 1,
    "tests": 2,
    "passes": 2,
    "pending": 0,
    "failures": 0,
    "start": "2019-11-23T21:50:10.680Z",
    "end": "2019-11-23T21:50:11.042Z",
    "duration": 362
  },
  "failures": [],
  "passes": [
    {
      "title": "Opening a project",
      "duration": 28,
      "timedOut": false
    },
    {
      "title": "Opening the project list",
      "duration": 28,
      "timedOut": false
    }
  ]
}
```
</details>

<details>
<summary> after (both requests ran the test suite) </summary>

```
$ curl 127.0.0.1:3000/health_check & curl 127.0.0.1:3000/health_check
{
  "stats": {
    "suites": 1,
    "tests": 2,
    "passes": 2,
    "pending": 0,
    "failures": 0,
    "start": "2019-11-23T21:51:03.079Z",
    "end": "2019-11-23T21:51:03.475Z",
    "duration": 396
  },
  "failures": [],
  "passes": [
    {
      "title": "Opening a project",
      "duration": 29,
      "timedOut": false
    },
    {
      "title": "Opening the project list",
      "duration": 34,
      "timedOut": false
    }
  ]
}{
  "stats": {
    "suites": 1,
    "tests": 2,
    "passes": 2,
    "pending": 0,
    "failures": 0,
    "start": "2019-11-23T21:51:03.080Z",
    "end": "2019-11-23T21:51:03.477Z",
    "duration": 397
  },
  "failures": [],
  "passes": [
    {
      "title": "Opening a project",
      "duration": 34,
      "timedOut": false
    },
    {
      "title": "Opening the project list",
      "duration": 39,
      "timedOut": false
    }
  ]
}
```
</details>

#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [x] two concurrent requests
 `$ curl 127.0.0.1:3000/health_check & curl 127.0.0.1:3000/health_check`
- [x] 100 concurrent requests 
`$ ab -n 100 -c 100 127.0.0.1:3000/health_check`

NOTE: the login has a hardcoded rate limit for concurrent login attempts
 using the same email address. in order to replicate the 100 concurrent
 /health_check calls, this limit must be increased accordingly.
  app/src/Features/Security/LoginRateLimiter.js:15

#### Accessibility



### Deployment



#### Deployment Checklist

#### Metrics and Monitoring



#### Who Needs to Know?
