### PR TITLE
Feature relative image paths

### DIFF
--- a/frontend/stylesheets/app/editor.less
+++ b/frontend/stylesheets/app/editor.less
@@ -232,9 +232,9 @@ Ace
   }
   .spelling-highlight {
     position: absolute;
-    background-image: url(/img/spellcheck-underline.png);
+    background-image: url(../../../public/img/spellcheck-underline.png);
     @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-      background-image: url(/img/spellcheck-underline@2x.png);
+      background-image: url(../../../public/img/spellcheck-underline@2x.png);
       background-size: 5px 4px;
     }
     background-repeat: repeat-x;

--- a/frontend/stylesheets/app/editor/binary-file.less
+++ b/frontend/stylesheets/app/editor/binary-file.less
@@ -14,7 +14,7 @@
     background-color: white;
   }
   .img-preview {
-    background: url('/img/spinner.gif') no-repeat;
+    background: url('../../../../public/img/spinner.gif') no-repeat;
     min-width: 200px;
     min-height: 200px;
   }

--- a/frontend/stylesheets/app/editor/review-panel.less
+++ b/frontend/stylesheets/app/editor/review-panel.less
@@ -974,7 +974,7 @@
 
 .review-icon when (@is-overleaf = false) {
   display: inline-block;
-  background: url('/img/review-icon-sprite.png') top/30px no-repeat;
+  background: url('../../../../public/img/review-icon-sprite.png') top/30px no-repeat;
   width: 30px;
 
   &::before {
@@ -991,13 +991,13 @@
   }
 
   @media (min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-    background-image: url('/img/review-icon-sprite@2x.png');
+    background-image: url('../../../../public/img/review-icon-sprite@2x.png');
   }
 }
 
 .review-icon when (@is-overleaf = true) {
   display: inline-block;
-  background: url('/img/review-icon-sprite-ol.png') top/30px no-repeat;
+  background: url('../../../../public/img/review-icon-sprite-ol.png') top/30px no-repeat;
   width: 30px;
   background-position-y: -30px;
 
@@ -1006,7 +1006,7 @@
   }
 
   @media (min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-    background-image: url('/img/review-icon-sprite-ol@2x.png');
+    background-image: url('../../../../public/img/review-icon-sprite-ol@2x.png');
   }
 }
 

--- a/frontend/stylesheets/app/editor/rich-text.less
+++ b/frontend/stylesheets/app/editor/rich-text.less
@@ -247,7 +247,7 @@
   }
 
   .spelling-error {
-    background-image: url(/img/spellcheck-underline.png);
+    background-image: url(../../../../public/img/spellcheck-underline.png);
     background-repeat: repeat-x;
     background-position: bottom;
   }

--- a/frontend/stylesheets/app/error-pages.less
+++ b/frontend/stylesheets/app/error-pages.less
@@ -34,7 +34,7 @@
     bottom: 0;
     left: 0;
     right: 80%;
-    background-image: url(/img/brand/500-visual-plug.svg);
+    background-image: url(../../../public/img/brand/500-visual-plug.svg);
     background-size: 400px;
     background-repeat: no-repeat;
     background-position: right 70%;
@@ -48,7 +48,7 @@
     bottom: 0;
     left: 0;
     right: 50%;
-    background-image: url(/img/brand/500-visual-tail.svg);
+    background-image: url(../../../public/img/brand/500-visual-tail.svg);
     background-size: 100px;
     background-repeat: no-repeat;
     background-position: 90% bottom;

--- a/frontend/stylesheets/app/homepage.less
+++ b/frontend/stylesheets/app/homepage.less
@@ -13,7 +13,7 @@
   }
   .img {
     max-width: 420px;
-    background-image: url('/img/ol_plus_sl.png');
+    background-image: url('../../../public/img/ol_plus_sl.png');
     background-size: 100%;
     background-repeat: no-repeat;
     margin: 20px auto 0;
@@ -129,7 +129,7 @@
     max-width: 960px;
     .img {
       max-width: 960px;
-      background-image: url('/img/homepage.png');
+      background-image: url('../../../public/img/homepage.png');
       background-size: 100%;
       background-repeat: no-repeat;
       margin: auto;
@@ -142,7 +142,7 @@
       only screen and (min-resolution: 192dpi),
       only screen and (min-resolution: 2dppx) {
       .img {
-        background-image: url('/img/homepage@2x.png');
+        background-image: url('../../../public/img/homepage@2x.png');
       }
     }
   }
@@ -226,13 +226,13 @@
 }
 
 .pattern-container {
-  background: url('/img/pattern-home.png') repeat #f1f1f1;
+  background: url('../../../public/img/pattern-home.png') repeat #f1f1f1;
   border-top: 1px solid @gray-lightest;
   border-bottom: 1px solid @gray-lightest;
 }
 
 .pattern-grid {
-  background: url('/img/grid.png') repeat @content-alt-bg-color;
+  background: url('../../../public/img/grid.png') repeat @content-alt-bg-color;
   border-top: 1px solid @gray-lighter;
   border-bottom: 1px solid @gray-lighter;
 }

--- a/frontend/stylesheets/app/login-register.less
+++ b/frontend/stylesheets/app/login-register.less
@@ -117,7 +117,7 @@
   position: absolute;
   top: 4px;
   left: 4px;
-  background: #fff url(/img/brand/lion.svg) center/20px no-repeat;
+  background: #fff url(../../../public/img/brand/lion.svg) center/20px no-repeat;
   border-radius: 99999px;
   width: 26px;
   height: 26px;
@@ -128,16 +128,16 @@
 }
 
 .login-btn-icon-ieee {
-  background-image: url(/img/other-brands/logo_ieee.svg);
+  background-image: url(../../../public/img/other-brands/logo_ieee.svg);
 }
 .login-btn-icon-google {
-  background-image: url(/img/other-brands/logo_google.svg);
+  background-image: url(../../../public/img/other-brands/logo_google.svg);
 }
 .login-btn-icon-twitter {
-  background-image: url(/img/other-brands/logo_twitter.svg);
+  background-image: url(../../../public/img/other-brands/logo_twitter.svg);
 }
 .login-btn-icon-orcid {
-  background-image: url(/img/other-brands/logo_orcid.svg);
+  background-image: url(../../../public/img/other-brands/logo_orcid.svg);
 }
 .login-btn-icon-sharelatex {
   background-size: 22px;

--- a/frontend/stylesheets/app/project-list.less
+++ b/frontend/stylesheets/app/project-list.less
@@ -695,7 +695,8 @@ ul.project-list {
   right: 3%;
   width: 80px;
   height: 80px;
-  background: url(/img/brand/lion.svg) no-repeat center/80% transparent;
+  background: url(../../../public/img/brand/lion.svg) no-repeat center/80%
+    transparent;
   border-radius: 50%;
   box-shadow: none;
   z-index: 1;

--- a/frontend/stylesheets/app/sprites.less
+++ b/frontend/stylesheets/app/sprites.less
@@ -1,5 +1,5 @@
 .sprite-icon {
-  background-image: url('/img/sprite.png');
+  background-image: url('../../../public/img/sprite.png');
 }
 
 .sprite-icon-ko {

--- a/frontend/stylesheets/core/ol-light-variables.less
+++ b/frontend/stylesheets/core/ol-light-variables.less
@@ -78,7 +78,7 @@
 @toolbar-btn-hover-bg-color : @ol-blue-gray-0;
 @toolbar-icon-btn-color : @ol-blue-gray-3;
 @toolbar-icon-btn-hover-color : @ol-blue-gray-3;
-@editor-header-logo-background : url(/img/ol-brand/overleaf-o.svg) center / contain no-repeat;
+@editor-header-logo-background : url(../../../public/img/ol-brand/overleaf-o.svg) center / contain no-repeat;
 @project-name-color : @ol-blue-gray-3;
 @pdf-bg : @ol-blue-gray-0;
 
@@ -95,7 +95,7 @@
 @navbar-title-color : @ol-blue-gray-1;
 @navbar-title-color-hover : @ol-blue-gray-2;
 @navbar-default-color : @ol-blue-gray-3;
-@navbar-brand-image-url : url(/img/ol-brand/overleaf.svg);
+@navbar-brand-image-url : url(../../../public/img/ol-brand/overleaf.svg);
 
 @navbar-subdued-color : @ol-blue-gray-3;
 @navbar-subdued-hover-bg : @ol-blue-gray-1;

--- a/frontend/stylesheets/core/ol-variables.less
+++ b/frontend/stylesheets/core/ol-variables.less
@@ -34,7 +34,7 @@
 @navbar-default-color: #fff;
 @navbar-default-bg: @ol-blue-gray-6;
 @navbar-default-border: transparent;
-@navbar-brand-image-url: url(/img/ol-brand/overleaf-white.svg);
+@navbar-brand-image-url: url(../../../public/img/ol-brand/overleaf-white.svg);
 @navbar-default-link-bg: transparent;
 @nav-pills-active-link-hover-bg: @ol-dark-green;
 @nav-pills-link-color: @btn-default-bg;
@@ -400,9 +400,9 @@
 @brand-warning: @orange;
 @brand-danger: @ol-red;
 
-@editor-header-logo-background: url(/img/ol-brand/overleaf-o-white.svg) center /
-  contain no-repeat;
+@editor-header-logo-background: url(../../../public/img/ol-brand/overleaf-o-white.svg)
+  center / contain no-repeat;
 @editor-loading-logo-padding-top: 115.44%;
-@editor-loading-logo-background-url: url(/img/ol-brand/overleaf-o-grey.svg);
-@editor-loading-logo-foreground-url: url(/img/ol-brand/overleaf-o.svg);
+@editor-loading-logo-background-url: url(../../../public/img/ol-brand/overleaf-o-grey.svg);
+@editor-loading-logo-foreground-url: url(../../../public/img/ol-brand/overleaf-o.svg);
 @editor-search-count-color: @ol-blue-gray-4;

--- a/frontend/stylesheets/core/variables.less
+++ b/frontend/stylesheets/core/variables.less
@@ -25,10 +25,10 @@
 @brand-warning: @orange;
 @brand-danger: #e03a06;
 
-@navbar-brand-image-url: url(/img/brand/logo-horizontal.svg);
+@navbar-brand-image-url: url(../../../public/img/brand/logo-horizontal.svg);
 
 @editor-loading-logo-padding-top: 86.2%;
-@editor-loading-logo-background-url: url(/img/brand/lion-grey.svg);
-@editor-loading-logo-foreground-url: url(/img/brand/lion.svg);
+@editor-loading-logo-background-url: url(../../../public/img/brand/lion-grey.svg);
+@editor-loading-logo-foreground-url: url(../../../public/img/brand/lion.svg);
 
 @import '_common-variables.less';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7935,6 +7935,84 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-loader": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-5.0.2.tgz",
+      "integrity": "sha512-QMiQ+WBkGLejKe81HU8SZ9PovsU/5uaLo0JdTCEXOYv7i7jfAjHZi1tcwp9tSASJPOmmHZtbdCervFmXMH/Dcg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.5.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "dev": true
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "schema-utils": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+          "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^3.0.1",
     "expose-loader": "^0.7.5",
+    "file-loader": "^5.0.2",
     "glob": "^7.1.3",
     "handlebars-loader": "^1.7.0",
     "karma": "^2.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,13 @@ module.exports = {
         test: /\.less$/,
         use: [
           // Allows the CSS to be extracted to a separate .css file
-          { loader: MiniCssExtractPlugin.loader },
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              // filename is `stylesheets/....css` downstream, drop 1 level
+              publicPath: '../'
+            }
+          },
           // Resolves any CSS dependencies (e.g. url())
           { loader: 'css-loader' },
           {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -173,6 +173,18 @@ module.exports = {
             options: 'AlgoliaSearch'
           }
         ]
+      },
+      {
+        // preserve assets that are already in the output directory
+        test: new RegExp(`^${path.join(__dirname, 'public')}`),
+        loader: 'file-loader',
+        options: {
+          // preserve the exact filepath
+          context: 'public',
+          name: '[path][name].[ext]',
+          // use the file inplace
+          emitFile: false
+        }
       }
     ]
   },


### PR DESCRIPTION
### Description
Images are currently hard linked to the root of its serving origin. Using relative paths we can serve multiple versions of the assets from the same cdn domain - or use a multi purpose cdn as in `https://cdn.example.com/overleaf/`. Additionally some IDEs will allow an easy navigation from the css rule to the actual image.

Webpack will error out in case it can not find a linked image.

#### Screenshots



#### Related Issues / PRs



### Review
- https://github.com/overleaf/web/commit/8fbd8935f028dfc1201f3c0fcf28e240edfe8878 should be trivial.

- https://github.com/overleaf/web/commit/eff51a0cb5d3f411bbfb044de886a643ed82adc9 is slightly hacky but I could not find a simpler option that does A) not emit a new file and B) preserves to uri of the resources. Just using the `file-loader` would create new files like `fd2a63eeee604ff679003c8c28c41386.svg` in the public/ directory and like these from css instead. Using the ignore plugin does not work as it would complain for the missing resources.

#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
