### PR TITLE
[misc] fileOperationI18nNames: drop blocking DOM access

### DIFF
--- a/app/views/project/editor/history/fileTreeV2.pug
+++ b/app/views/project/editor/history/fileTreeV2.pug
@@ -56,7 +56,6 @@ script(type="text/ng-template", id="historyFileEntityTpl")
 				file-entity="childEntity"
 			)
 
-script(type="template", id="file_action_edited_str") #{ translate('file_action_edited') }
-script(type="template", id="file_action_renamed_str") #{ translate('file_action_renamed') }
-script(type="template", id="file_action_created_str") #{ translate('file_action_created') }
-script(type="template", id="file_action_deleted_str") #{ translate('file_action_deleted') }
+- var fileActionI18n = ['edited', 'renamed', 'created', 'deleted'].reduce((acc, i) => {acc[i] = translate('file_action_' + i); return acc}, {})
+script(type="text/javascript").
+	window.fileActionI18n = JSON.parse('!{StringHelper.stringifyJsonForScript(fileActionI18n)}')

--- a/frontend/js/ide/file-tree/util/fileOperationI18nNames.js
+++ b/frontend/js/ide/file-tree/util/fileOperationI18nNames.js
@@ -1,8 +1,11 @@
 define([], function() {
+  if (window.fileActionI18n !== undefined) {
+    return window.fileActionI18n
+  }
   return {
-    edited: document.getElementById('file_action_edited_str').innerText,
-    renamed: document.getElementById('file_action_renamed_str').innerText,
-    created: document.getElementById('file_action_created_str').innerText,
-    deleted: document.getElementById('file_action_deleted_str').innerText
+    edited: 'edited',
+    renamed: 'renamed',
+    created: 'created',
+    deleted: 'deleted'
   }
 })

--- a/test/frontend/import_tests.js
+++ b/test/frontend/import_tests.js
@@ -25,19 +25,6 @@ chai.Assertion.addMethod('equalPos', function(expectedPos) {
 // Mock ExposedSettings
 window.ExposedSettings = {}
 
-// Mock the file operation I18n names that are stored in the DOM
-function mockFileOperationI18nNames(id, text) {
-  const el = document.createElement('div')
-  el.id = id
-  el.innerText = text
-  el.setAttribute('hidden', true)
-  document.body.appendChild(el)
-}
-mockFileOperationI18nNames('file_action_edited_str', 'edited')
-mockFileOperationI18nNames('file_action_renamed_str', 'renamed')
-mockFileOperationI18nNames('file_action_created_str', 'created')
-mockFileOperationI18nNames('file_action_deleted_str', 'deleted')
-
 /*
  * Bundle all test files together into a single bundle, and run tests against
  * this single bundle.


### PR DESCRIPTION
### Description
`.innerText` is a blocking dom operation and requires e.g. font files to be loaded already.

The four strings are better put into a single json blob and parsed back in the front-end js.

#### Screenshots



#### Related Issues / PRs



### Review


#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
