### PR TITLE
fix token expired in register

### DIFF
--- a/app/src/Features/User/UserController.js
+++ b/app/src/Features/User/UserController.js
@@ -16,6 +16,7 @@ const Errors = require('../Errors/Errors')
 const OError = require('@overleaf/o-error')
 const HttpErrors = require('@overleaf/o-error/http')
 const EmailHandler = require('../Email/EmailHandler')
+const EmailHelper = require('../Helpers/EmailHelper')
 const UrlHelper = require('../Helpers/UrlHelper')
 const { promisify } = require('util')
 
@@ -337,7 +338,7 @@ const UserController = {
   },
 
   register(req, res, next) {
-    const { email } = req.body
+    const email = EmailHelper.parseEmail(req.body.email)
     if (email == null || email === '') {
       return res.sendStatus(422) // Unprocessable Entity
     }


### PR DESCRIPTION
### Description
When the registered email contains uppercase letters, access `user/activate?token={your token}&user_id={your user_id}` will show that the activation code has expired.

#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
