### PR TITLE
Avoid JSON indirect parsing

### DIFF
--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -75,7 +75,7 @@ html(
 			};
 			window.ab = {};
 			window.user_id = '#{getLoggedInUserId()}';
-			window.ExposedSettings = JSON.parse('!{StringHelper.stringifyJsonForScript(ExposedSettings)}');
+			window.ExposedSettings = !{StringHelper.stringifyJsonForScript(ExposedSettings)};
 
 		- if (typeof(settings.algolia) != "undefined")
 			script.

--- a/app/views/project/editor.pug
+++ b/app/views/project/editor.pug
@@ -175,7 +175,7 @@ block content
 		window.aceBasePath = "/js/#{lib('ace')}"
 		//- Set path for PDFjs CMaps
 		window.pdfCMapsPath = "/js/cmaps/"
-		window.uiConfig = JSON.parse('!{StringHelper.stringifyJsonForScript(uiConfig)}');
+		window.uiConfig = !{StringHelper.stringifyJsonForScript(uiConfig)};
 		//- enable doc hash checking for all projects
 		//- used in public/js/libs/sharejs.js
 		window.useShareJsHash = true
@@ -183,7 +183,7 @@ block content
 
 	- if (settings.overleaf != null)
 		script(type='text/javascript').
-			window.overallThemes = JSON.parse('!{StringHelper.stringifyJsonForScript(overallThemes)}');
+			window.overallThemes = !{StringHelper.stringifyJsonForScript(overallThemes)};
 
 block foot-scripts
 	script(type="text/javascript" src=(wsUrl || '/socket.io') + '/socket.io.js')

--- a/app/views/project/editor/history/fileTreeV2.pug
+++ b/app/views/project/editor/history/fileTreeV2.pug
@@ -58,4 +58,4 @@ script(type="text/ng-template", id="historyFileEntityTpl")
 
 - var fileActionI18n = ['edited', 'renamed', 'created', 'deleted'].reduce((acc, i) => {acc[i] = translate('file_action_' + i); return acc}, {})
 script(type="text/javascript").
-	window.fileActionI18n = JSON.parse('!{StringHelper.stringifyJsonForScript(fileActionI18n)}')
+	window.fileActionI18n = !{StringHelper.stringifyJsonForScript(fileActionI18n)}


### PR DESCRIPTION
### Description
Replace `JSON.parse('!{StringHelper.stringifyJsonForScript(ExposedSettings)}')` by just `!{StringHelper.stringifyJsonForScript(ExposedSettings)}` because the old construction is useless (JSON is valid JS anyway) and doesn't escape the object properly (`'` in strings lead to errors)


#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [x] Deployed on personal Overleaf Community Edition install where it fixed a bug related to a single quote `'` in APP_NAME
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
