### PR TITLE
Resolve #659: Relative line numbers for vim

### DIFF
--- a/frontend/js/ide/editor/directives/aceEditor.js
+++ b/frontend/js/ide/editor/directives/aceEditor.js
@@ -455,10 +455,16 @@ App.directive('aceEditor', function(
       scope.$watch('showPrintMargin', value => editor.setShowPrintMargin(value))
 
       scope.$watch('keybindings', function(value) {
-        if (['vim', 'emacs'].includes(value)) {
-          return editor.setKeyboardHandler(`ace/keyboard/${value}`)
-        } else {
-          return editor.setKeyboardHandler(null)
+        switch (value) {
+          case 'vim':
+            editor.setKeyboardHandler('ace/keyboard/vim');
+            return editor.setOption('relativeLineNumbers', true);
+          case 'emacs':
+            editor.setKeyboardHandler('ace/keyboard/emacs');
+            return editor.setOption('relativeLineNumbers', false);
+          default:
+            editor.setKeyboardHandler(null);
+            return editor.setOption('relativeLineNumbers', false);
         }
       })
 


### PR DESCRIPTION
### Description
This is a quick and simple solution without adding fine tuned controls for line number display. This forces vim mode to use relative line numbers for simplicity because honestly, I don't think any vim users would ever want absolute line numbers...

#### Screenshots



#### Related Issues / PRs
#659 


### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
