### PR TITLE
Fix file naming for PDF downloads

### DIFF
--- a/app/src/Features/Compile/CompileController.js
+++ b/app/src/Features/Compile/CompileController.js
@@ -264,8 +264,8 @@ module.exports = CompileController = {
   },
 
   _getSafeProjectName(project) {
-    const wordRegExp = /\W/g
-    const safeProjectName = project.name.replace(wordRegExp, '_')
+    // Only allow alphanumeric and ( ) @ - characters in filenames
+    const safeProjectName = project.name.replace(new RegExp('[^\\w\\(\\)\\@\\-]', 'g'), '_')
     return sanitize.escape(safeProjectName)
   },
 


### PR DESCRIPTION
Our documents contain `@` as well as `-` symbols. We do not consider them harmful and projects can have the symbols in their name.
As copies of projects have (1) in their name, it would also make sense to include them into the regular expression. `...replace(new RegExp('[^\\(\\)\\@\\-\\w]', 'g'), '_')`

### Description



#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
